### PR TITLE
Station tip and erroneous thermistor string flags added

### DIFF
--- a/flags/NUK_L.csv
+++ b/flags/NUK_L.csv
@@ -29,7 +29,7 @@ t0, t1, variable, flag, comment, URL_graphic
 2018-02-01T08:00:00+00:00,2018-02-02T20:00:00+00:00,ulr,CHECKME,manually flagged by bav,
 2018-02-03T14:00:00+00:00,2018-02-06T00:00:00+00:00,ulr,CHECKME,manually flagged by bav,
 
-2010-07-25T00:00:00+00:00,2010-10-19T00:00:00+00:00,2025-05-19T00:00:00+00:00,,gps_lon,NAN,manually flagged by bav,https://github.com/GEUS-Glaciology-and-Climate/PROMICE-AWS-data-issues/issues/154
+2010-07-25T00:00:00+00:00,2010-10-19T00:00:00+00:00,gps_lon,NAN,manually flagged by bav,https://github.com/GEUS-Glaciology-and-Climate/PROMICE-AWS-data-issues/issues/154
 
 2023-05-30T10:00:00+00:00,,t_i_2,NAN,erroneous thermistor measurements (pho)
 2023-07-11T07:00:00+00:00,,t_i_6,NAN,erroneous thermistor measurements (pho)

--- a/flags/NUK_L.csv
+++ b/flags/NUK_L.csv
@@ -29,4 +29,9 @@ t0, t1, variable, flag, comment, URL_graphic
 2018-02-01T08:00:00+00:00,2018-02-02T20:00:00+00:00,ulr,CHECKME,manually flagged by bav,
 2018-02-03T14:00:00+00:00,2018-02-06T00:00:00+00:00,ulr,CHECKME,manually flagged by bav,
 
-2010-07-25T00:00:00+00:00,2010-10-19T00:00:00+00:00,gps_lon,NAN,manually flagged by bav,https://github.com/GEUS-Glaciology-and-Climate/PROMICE-AWS-data-issues/issues/154
+2010-07-25T00:00:00+00:00,2010-10-19T00:00:00+00:00,2025-05-19T00:00:00+00:00,,gps_lon,NAN,manually flagged by bav,https://github.com/GEUS-Glaciology-and-Climate/PROMICE-AWS-data-issues/issues/154
+
+2023-05-30T10:00:00+00:00,,t_i_2,NAN,erroneous thermistor measurements (pho)
+2023-07-11T07:00:00+00:00,,t_i_6,NAN,erroneous thermistor measurements (pho)
+
+2025-05-19T00:00:00+00:00,,wspd_u wspd_i wdir_u wdir_i dsr usr dlr ulr z_boom_u z_pt tilt_x tilt_y,NAN,station started tipping (pho)


### PR DESCRIPTION
1. NUK_Lv2 station tip added with corresponding NAN flags. Period logged from time that it is suspected that station began to lean significantly (2025-05-19). Station tip actually occurred on 2025-05-30. Station found tipped during station visit on 2025-06-07

![IMG_4268_small](https://github.com/user-attachments/assets/b4b4fe81-3fdf-45d3-be32-bb6ce876d9f4)

2. NUK_Lv2 `t_i_2` and `t_i_6` values flagged from 2023 as they are erroneous